### PR TITLE
Update to pydantic v2

### DIFF
--- a/btrack/config.py
+++ b/btrack/config.py
@@ -115,28 +115,10 @@ class TrackerConfig(BaseModel):
     model_config = {
         "arbitrary_types_allowed": True,
         "validate_assignment": True,
-        "json_schema_extra": {"json_encoders": {
+        "json_encoders": {
             np.ndarray: lambda x: x.ravel().tolist(),
-        }}
+        }
     }
-    
-    @classmethod
-    def __get_pydantic_core_schema__(
-        cls, _source_type: Any, _handler: Any
-    ) -> core_schema.CoreSchema:
-        """Define serialization for numpy arrays."""
-        schema = _handler(_source_type)
-        
-        def serialize_numpy_arrays(obj: Any) -> Any:
-            for field_name, field_value in obj.items():
-                if isinstance(field_value, np.ndarray):
-                    obj[field_name] = field_value.ravel().tolist()
-            return obj
-            
-        schema["serialization"] = core_schema.wrap_serializer_function_ser_schema(
-            serialize_numpy_arrays
-        )
-        return schema
 
 
 def load_config(filename: os.PathLike) -> TrackerConfig:

--- a/btrack/config.py
+++ b/btrack/config.py
@@ -93,7 +93,7 @@ class TrackerConfig(BaseModel):
         min_length=1,
         max_length=len(constants.BayesianUpdateFeatures)
     )
-    enable_optimisation = True
+    enable_optimisation: bool = True
 
     @field_validator("volume", mode="before")
     @classmethod

--- a/btrack/config.py
+++ b/btrack/config.py
@@ -89,11 +89,10 @@ class TrackerConfig(BaseModel):
     optimizer_options: dict = constants.GLPK_OPTIONS
     features: list[str] = []
     tracking_updates: list[constants.BayesianUpdateFeatures] = Field(
+        default=[constants.BayesianUpdateFeatures.MOTION],
         min_length=1,
         max_length=len(constants.BayesianUpdateFeatures)
-    ) = [
-        constants.BayesianUpdateFeatures.MOTION,
-    ]
+    )
     enable_optimisation = True
 
     @field_validator("volume", mode="before")

--- a/btrack/config.py
+++ b/btrack/config.py
@@ -134,7 +134,7 @@ class TrackerConfig(BaseModel):
             return obj
             
         schema["serialization"] = core_schema.wrap_serializer_function_ser_schema(
-            serialize_numpy_arrays, schema.get("serialization")
+            serialize_numpy_arrays
         )
         return schema
 

--- a/btrack/models.py
+++ b/btrack/models.py
@@ -182,7 +182,7 @@ class MotionModel(BaseModel):
             return obj
             
         schema["serialization"] = core_schema.wrap_serializer_function_ser_schema(
-            serialize_numpy_arrays, schema.get("serialization")
+            serialize_numpy_arrays
         )
         return schema
 
@@ -256,7 +256,7 @@ class ObjectModel(BaseModel):
             return obj
             
         schema["serialization"] = core_schema.wrap_serializer_function_ser_schema(
-            serialize_numpy_arrays, schema.get("serialization")
+            serialize_numpy_arrays
         )
         return schema
 
@@ -383,6 +383,6 @@ class HypothesisModel(BaseModel):
             return obj
             
         schema["serialization"] = core_schema.wrap_serializer_function_ser_schema(
-            serialize_numpy_arrays, schema.get("serialization")
+            serialize_numpy_arrays
         )
         return schema

--- a/btrack/models.py
+++ b/btrack/models.py
@@ -163,28 +163,10 @@ class MotionModel(BaseModel):
     model_config = {
         "arbitrary_types_allowed": True,
         "validate_assignment": True,
-        "json_schema_extra": {"json_encoders": {
+        "json_encoders": {
             np.ndarray: lambda x: x.ravel().tolist(),
-        }}
+        }
     }
-    
-    @classmethod
-    def __get_pydantic_core_schema__(
-        cls, _source_type: Any, _handler: Any
-    ) -> core_schema.CoreSchema:
-        """Define serialization for numpy arrays."""
-        schema = _handler(_source_type)
-        
-        def serialize_numpy_arrays(obj: Any) -> Any:
-            for field_name, field_value in obj.items():
-                if isinstance(field_value, np.ndarray):
-                    obj[field_name] = field_value.ravel().tolist()
-            return obj
-            
-        schema["serialization"] = core_schema.wrap_serializer_function_ser_schema(
-            serialize_numpy_arrays
-        )
-        return schema
 
 
 class ObjectModel(BaseModel):
@@ -237,28 +219,10 @@ class ObjectModel(BaseModel):
     model_config = {
         "arbitrary_types_allowed": True,
         "validate_assignment": True,
-        "json_schema_extra": {"json_encoders": {
+        "json_encoders": {
             np.ndarray: lambda x: x.ravel().tolist(),
-        }}
+        }
     }
-    
-    @classmethod
-    def __get_pydantic_core_schema__(
-        cls, _source_type: Any, _handler: Any
-    ) -> core_schema.CoreSchema:
-        """Define serialization for numpy arrays."""
-        schema = _handler(_source_type)
-        
-        def serialize_numpy_arrays(obj: Any) -> Any:
-            for field_name, field_value in obj.items():
-                if isinstance(field_value, np.ndarray):
-                    obj[field_name] = field_value.ravel().tolist()
-            return obj
-            
-        schema["serialization"] = core_schema.wrap_serializer_function_ser_schema(
-            serialize_numpy_arrays
-        )
-        return schema
 
 
 class HypothesisModel(BaseModel):
@@ -364,25 +328,7 @@ class HypothesisModel(BaseModel):
 
     model_config = {
         "validate_assignment": True,
-        "json_schema_extra": {"json_encoders": {
+        "json_encoders": {
             np.ndarray: lambda x: x.ravel().tolist(),
-        }}
+        }
     }
-    
-    @classmethod
-    def __get_pydantic_core_schema__(
-        cls, _source_type: Any, _handler: Any
-    ) -> core_schema.CoreSchema:
-        """Define serialization for numpy arrays."""
-        schema = _handler(_source_type)
-        
-        def serialize_numpy_arrays(obj: Any) -> Any:
-            for field_name, field_value in obj.items():
-                if isinstance(field_value, np.ndarray):
-                    obj[field_name] = field_value.ravel().tolist()
-            return obj
-            
-        schema["serialization"] = core_schema.wrap_serializer_function_ser_schema(
-            serialize_numpy_arrays
-        )
-        return schema

--- a/btrack/models.py
+++ b/btrack/models.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import numpy as np
 from numpy import typing as npt
-from pydantic import BaseModel, root_validator, validator
+from pydantic import BaseModel, field_validator, model_validator
 
 from . import constants
 from .optimise.hypothesis import H_TYPES, PyHypothesisParams
@@ -91,7 +91,8 @@ class MotionModel(BaseModel):
     prob_not_assign: float = constants.PROB_NOT_ASSIGN
     name: str = "Default"
 
-    @validator("A", "H", "P", "R", "G", "Q", pre=True)
+    @field_validator("A", "H", "P", "R", "G", "Q", mode="before")
+    @classmethod
     def parse_arrays(cls, v):
         if isinstance(v, dict):
             m = v.get("matrix", None)
@@ -99,57 +100,69 @@ class MotionModel(BaseModel):
             return np.asarray(m, dtype=float) * s
         return np.asarray(v, dtype=float)
 
-    @validator("A")
-    def reshape_A(cls, a, values):
+    @field_validator("A")
+    @classmethod
+    def reshape_A(cls, a, info):
+        values = info.data
         shape = (values["states"], values["states"])
         return np.reshape(a, shape)
 
-    @validator("H")
-    def reshape_H(cls, h, values):
+    @field_validator("H")
+    @classmethod
+    def reshape_H(cls, h, info):
+        values = info.data
         shape = (values["measurements"], values["states"])
         return np.reshape(h, shape)
 
-    @validator("P")
-    def reshape_P(cls, p, values):
+    @field_validator("P")
+    @classmethod
+    def reshape_P(cls, p, info):
+        values = info.data
         shape = (values["states"], values["states"])
         p = np.reshape(p, shape)
         if not _check_symmetric(p):
             raise ValueError("Matrix `P` is not symmetric.")
         return p
 
-    @validator("R")
-    def reshape_R(cls, r, values):
+    @field_validator("R")
+    @classmethod
+    def reshape_R(cls, r, info):
+        values = info.data
         shape = (values["measurements"], values["measurements"])
         r = np.reshape(r, shape)
         if not _check_symmetric(r):
             raise ValueError("Matrix `R` is not symmetric.")
         return r
 
-    @validator("G")
-    def reshape_G(cls, g, values):
+    @field_validator("G")
+    @classmethod
+    def reshape_G(cls, g, info):
+        values = info.data
         shape = (1, values["states"])
         return np.reshape(g, shape)
 
-    @validator("Q")
-    def reshape_Q(cls, q, values):
+    @field_validator("Q")
+    @classmethod
+    def reshape_Q(cls, q, info):
+        values = info.data
         shape = (values["states"], values["states"])
         q = np.reshape(q, shape)
         if not _check_symmetric(q):
             raise ValueError("Matrix `Q` is not symmetric.")
         return q
 
-    @root_validator
-    def validate_motion_model(cls, values):
-        if values["Q"] is None:
-            G = values.get("G", None)
-            if G is None:
+    @model_validator(mode="after")
+    def validate_motion_model(self):
+        if self.Q is None:
+            if self.G is None:
                 raise ValueError("Either a `G` or `Q` matrix is required.")
-            values["Q"] = G.T @ G
-        return values
+            self.Q = self.G.T @ self.G
+        return self
 
-    class Config:
-        arbitrary_types_allowed = True
-        validate_assignment = True
+    model_config = {
+        "arbitrary_types_allowed": True,
+        "validate_assignment": True
+    }
 
 
 class ObjectModel(BaseModel):
@@ -179,23 +192,30 @@ class ObjectModel(BaseModel):
     start: npt.NDArray
     name: str = "Default"
 
-    @validator("emission", "transition", "start", pre=True)
-    def parse_array(cls, v, values):
+    @field_validator("emission", "transition", "start", mode="before")
+    @classmethod
+    def parse_array(cls, v, info):
+        values = info.data
         return np.asarray(v, dtype=float)
 
-    @validator("emission", "transition", "start", pre=True)
-    def reshape_emission_transition(cls, v, values):
+    @field_validator("emission", "transition", mode="before")
+    @classmethod
+    def reshape_emission_transition(cls, v, info):
+        values = info.data
         shape = (values["states"], values["states"])
         return np.reshape(v, shape)
 
-    @validator("emission", "transition", "start", pre=True)
-    def reshape_start(cls, v, values):
+    @field_validator("start", mode="before")
+    @classmethod
+    def reshape_start(cls, v, info):
+        values = info.data
         shape = (1, values["states"])
         return np.reshape(v, shape)
 
-    class Config:
-        arbitrary_types_allowed = True
-        validate_assignment = True
+    model_config = {
+        "arbitrary_types_allowed": True,
+        "validate_assignment": True
+    }
 
 
 class HypothesisModel(BaseModel):
@@ -274,7 +294,8 @@ class HypothesisModel(BaseModel):
     relax: bool
     name: str = "Default"
 
-    @validator("hypotheses", pre=True)
+    @field_validator("hypotheses", mode="before")
+    @classmethod
     def parse_hypotheses(cls, hypotheses):
         if any(h not in H_TYPES for h in hypotheses):
             raise ValueError("Unknown hypothesis type in `hypotheses`.")
@@ -290,7 +311,7 @@ class HypothesisModel(BaseModel):
         h_params = PyHypothesisParams()
         fields = [f[0] for f in h_params._fields_]
 
-        for k, v in self.dict().items():
+        for k, v in self.model_dump().items():
             if k in fields:
                 setattr(h_params, k, v)
 
@@ -298,5 +319,6 @@ class HypothesisModel(BaseModel):
         h_params.hypotheses_to_generate = self.hypotheses_to_generate()
         return h_params
 
-    class Config:
-        validate_assignment = True
+    model_config = {
+        "validate_assignment": True
+    }

--- a/btrack/models.py
+++ b/btrack/models.py
@@ -1,8 +1,9 @@
-from typing import Optional
+from typing import Any, Optional
 
 import numpy as np
 from numpy import typing as npt
 from pydantic import BaseModel, field_validator, model_validator
+from pydantic_core import core_schema
 
 from . import constants
 from .optimise.hypothesis import H_TYPES, PyHypothesisParams
@@ -161,8 +162,29 @@ class MotionModel(BaseModel):
 
     model_config = {
         "arbitrary_types_allowed": True,
-        "validate_assignment": True
+        "validate_assignment": True,
+        "json_schema_extra": {"json_encoders": {
+            np.ndarray: lambda x: x.ravel().tolist(),
+        }}
     }
+    
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, _source_type: Any, _handler: Any
+    ) -> core_schema.CoreSchema:
+        """Define serialization for numpy arrays."""
+        schema = _handler(_source_type)
+        
+        def serialize_numpy_arrays(obj: Any) -> Any:
+            for field_name, field_value in obj.items():
+                if isinstance(field_value, np.ndarray):
+                    obj[field_name] = field_value.ravel().tolist()
+            return obj
+            
+        schema["serialization"] = core_schema.wrap_serializer_function_ser_schema(
+            serialize_numpy_arrays, schema.get("serialization")
+        )
+        return schema
 
 
 class ObjectModel(BaseModel):
@@ -214,8 +236,29 @@ class ObjectModel(BaseModel):
 
     model_config = {
         "arbitrary_types_allowed": True,
-        "validate_assignment": True
+        "validate_assignment": True,
+        "json_schema_extra": {"json_encoders": {
+            np.ndarray: lambda x: x.ravel().tolist(),
+        }}
     }
+    
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, _source_type: Any, _handler: Any
+    ) -> core_schema.CoreSchema:
+        """Define serialization for numpy arrays."""
+        schema = _handler(_source_type)
+        
+        def serialize_numpy_arrays(obj: Any) -> Any:
+            for field_name, field_value in obj.items():
+                if isinstance(field_value, np.ndarray):
+                    obj[field_name] = field_value.ravel().tolist()
+            return obj
+            
+        schema["serialization"] = core_schema.wrap_serializer_function_ser_schema(
+            serialize_numpy_arrays, schema.get("serialization")
+        )
+        return schema
 
 
 class HypothesisModel(BaseModel):
@@ -320,5 +363,26 @@ class HypothesisModel(BaseModel):
         return h_params
 
     model_config = {
-        "validate_assignment": True
+        "validate_assignment": True,
+        "json_schema_extra": {"json_encoders": {
+            np.ndarray: lambda x: x.ravel().tolist(),
+        }}
     }
+    
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, _source_type: Any, _handler: Any
+    ) -> core_schema.CoreSchema:
+        """Define serialization for numpy arrays."""
+        schema = _handler(_source_type)
+        
+        def serialize_numpy_arrays(obj: Any) -> Any:
+            for field_name, field_value in obj.items():
+                if isinstance(field_value, np.ndarray):
+                    obj[field_name] = field_value.ravel().tolist()
+            return obj
+            
+        schema["serialization"] = core_schema.wrap_serializer_function_ser_schema(
+            serialize_numpy_arrays, schema.get("serialization")
+        )
+        return schema

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "numpy>=1.17.3",
     "pandas>=2.0.3",
     "pooch>=1.0.0",
-    "pydantic<2",
+    "pydantic>=2.0.0",
     "scikit-image>=0.16.2",
     "scipy>=1.3.1",
     "tqdm>=4.65.0",


### PR DESCRIPTION
## Description
This PR updates the repository to be compatible with Pydantic v2.

### Changes
* Changed dependency from `pydantic<2` to `pydantic>=2.0.0`
* Updated validator syntax to use `field_validator` and `model_validator`
* Updated `class Config` to `model_config`
* Updated `dict()` to `model_dump()`
* Fixed validator patterns to match Pydantic v2 requirements
* Fixed JSON serialization of NumPy arrays:
  * Removed custom `__get_pydantic_core_schema__` methods that were causing serialization errors
  * Updated model config to use `json_encoders` directly rather than nested inside `json_schema_extra`
  * Ensured proper serialization of NumPy arrays in all Pydantic models

### Motivation
This change will allow btrack to be used with newer Python libraries that require Pydantic v2. Many modern packages now depend on Pydantic v2, and this update ensures compatibility with the broader Python ecosystem.

### Fixed Issues
* Resolved multiple `PydanticSerializationError` errors that were occurring during JSON serialization
* Fixed serialization of NumPy arrays in configuration files and model exports
* Ensured all tests pass with the updated Pydantic version

### Testing
These changes have been tested to ensure the application works correctly with Pydantic v2:
* All previously failing tests now pass
* Configuration loading and saving works correctly
* Tracker export functionality works as expected
* napari plugin widgets function correctly