### PR TITLE
Fix Pydantic v2 serialization for NumPy arrays

### DIFF
--- a/btrack/config.py
+++ b/btrack/config.py
@@ -115,28 +115,10 @@ class TrackerConfig(BaseModel):
     model_config = {
         "arbitrary_types_allowed": True,
         "validate_assignment": True,
-        "json_schema_extra": {"json_encoders": {
+        "json_encoders": {
             np.ndarray: lambda x: x.ravel().tolist(),
-        }}
+        }
     }
-    
-    @classmethod
-    def __get_pydantic_core_schema__(
-        cls, _source_type: Any, _handler: Any
-    ) -> core_schema.CoreSchema:
-        """Define serialization for numpy arrays."""
-        schema = _handler(_source_type)
-        
-        def serialize_numpy_arrays(obj: Any) -> Any:
-            for field_name, field_value in obj.items():
-                if isinstance(field_value, np.ndarray):
-                    obj[field_name] = field_value.ravel().tolist()
-            return obj
-            
-        schema["serialization"] = core_schema.wrap_serializer_function_ser_schema(
-            serialize_numpy_arrays
-        )
-        return schema
 
 
 def load_config(filename: os.PathLike) -> TrackerConfig:

--- a/btrack/models.py
+++ b/btrack/models.py
@@ -163,28 +163,10 @@ class MotionModel(BaseModel):
     model_config = {
         "arbitrary_types_allowed": True,
         "validate_assignment": True,
-        "json_schema_extra": {"json_encoders": {
+        "json_encoders": {
             np.ndarray: lambda x: x.ravel().tolist(),
-        }}
+        }
     }
-    
-    @classmethod
-    def __get_pydantic_core_schema__(
-        cls, _source_type: Any, _handler: Any
-    ) -> core_schema.CoreSchema:
-        """Define serialization for numpy arrays."""
-        schema = _handler(_source_type)
-        
-        def serialize_numpy_arrays(obj: Any) -> Any:
-            for field_name, field_value in obj.items():
-                if isinstance(field_value, np.ndarray):
-                    obj[field_name] = field_value.ravel().tolist()
-            return obj
-            
-        schema["serialization"] = core_schema.wrap_serializer_function_ser_schema(
-            serialize_numpy_arrays
-        )
-        return schema
 
 
 class ObjectModel(BaseModel):
@@ -237,28 +219,10 @@ class ObjectModel(BaseModel):
     model_config = {
         "arbitrary_types_allowed": True,
         "validate_assignment": True,
-        "json_schema_extra": {"json_encoders": {
+        "json_encoders": {
             np.ndarray: lambda x: x.ravel().tolist(),
-        }}
+        }
     }
-    
-    @classmethod
-    def __get_pydantic_core_schema__(
-        cls, _source_type: Any, _handler: Any
-    ) -> core_schema.CoreSchema:
-        """Define serialization for numpy arrays."""
-        schema = _handler(_source_type)
-        
-        def serialize_numpy_arrays(obj: Any) -> Any:
-            for field_name, field_value in obj.items():
-                if isinstance(field_value, np.ndarray):
-                    obj[field_name] = field_value.ravel().tolist()
-            return obj
-            
-        schema["serialization"] = core_schema.wrap_serializer_function_ser_schema(
-            serialize_numpy_arrays
-        )
-        return schema
 
 
 class HypothesisModel(BaseModel):
@@ -364,25 +328,7 @@ class HypothesisModel(BaseModel):
 
     model_config = {
         "validate_assignment": True,
-        "json_schema_extra": {"json_encoders": {
+        "json_encoders": {
             np.ndarray: lambda x: x.ravel().tolist(),
-        }}
+        }
     }
-    
-    @classmethod
-    def __get_pydantic_core_schema__(
-        cls, _source_type: Any, _handler: Any
-    ) -> core_schema.CoreSchema:
-        """Define serialization for numpy arrays."""
-        schema = _handler(_source_type)
-        
-        def serialize_numpy_arrays(obj: Any) -> Any:
-            for field_name, field_value in obj.items():
-                if isinstance(field_value, np.ndarray):
-                    obj[field_name] = field_value.ravel().tolist()
-            return obj
-            
-        schema["serialization"] = core_schema.wrap_serializer_function_ser_schema(
-            serialize_numpy_arrays
-        )
-        return schema


### PR DESCRIPTION
## Description
This PR fixes the serialization errors occurring with Pydantic v2. The issue was caused by the custom serialization schema not being compatible with Pydantic v2's serialization process.

### Changes
- Remove custom `__get_pydantic_core_schema__` methods from all models that were causing `PydanticSerializationError`
- Use the simpler `json_encoders` approach in model_config which is compatible with Pydantic v2
- Move json_encoders from inside json_schema_extra to be a top-level key in model_config

### Testing
These changes should fix the failing tests related to JSON serialization while keeping the behavior unchanged:
- `test_config_to_widgets_round_trip`
- `test_save_button`
- `test_export_config`
- `test_config_to_json`
- `test_config_tracker`
- `test_tracker_export`
- `test_write_tracks_only`
- `test_write_lbep`
- `test_tracker` and related tests

This is a minimal change to address the issue without significant refactoring.